### PR TITLE
ref/37 중복 초대 안되도록 로직 변경

### DIFF
--- a/src/main/java/com/ll/TeamSteam/domain/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/com/ll/TeamSteam/domain/chatRoom/entity/ChatRoom.java
@@ -48,22 +48,6 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatRoom",  cascade = PERSIST)
     private List<ChatMessage> chatMessages = new ArrayList<>();
 
-    private LocalDateTime isUnlockCoolTime;
-
-    //TODO : 리팩토링
-    public boolean isModifyUnlocked() {
-        if (isUnlockCoolTime == null) {
-            return true;  // or false, depending on your business requirements
-        }
-        boolean whatIsTrueFalse = isUnlockCoolTime.isBefore(LocalDateTime.now());
-        log.info("whatIsTrueFalse = {} ", whatIsTrueFalse);
-        return whatIsTrueFalse;
-    }
-
-    public void updateCoolTime(LocalDateTime unLockCoolTime){
-        this.isUnlockCoolTime = unLockCoolTime;
-    }
-
     public static ChatRoom create(String name, Matching matching, User owner) {
 
         Assert.notNull(name, "name는 널일 수 없습니다.");

--- a/src/main/java/com/ll/TeamSteam/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ll/TeamSteam/domain/notification/repository/NotificationRepository.java
@@ -13,5 +13,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     int countByInvitedUserAndReadDateIsNull(User user);
 
-    Optional<Notification> findFirstByInvitingUserAndInvitedUserAndRoomIdOrderByCreateDateDesc(User invitingUser, User invitedUser, Long roomId);
+    boolean existsByInvitingUserAndInvitedUserAndRoomId(User invitingUser, User invitedUser, Long roomId);
 }

--- a/src/main/java/com/ll/TeamSteam/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/notification/service/NotificationService.java
@@ -72,8 +72,7 @@ public class NotificationService {
         return notificationRepository.countByInvitedUserAndReadDateIsNull(user) > 0;
     }
 
-    public Optional<Notification> inviteCoolTime1Minute(User invitingUser, User invitedUser, Long roomId) {
-        return notificationRepository.findFirstByInvitingUserAndInvitedUserAndRoomIdOrderByCreateDateDesc(invitingUser, invitedUser, roomId);
+    public boolean checkDuplicateInvite(User invitingUser, User invitedUser, Long roomId) {
+        return notificationRepository.existsByInvitingUserAndInvitedUserAndRoomId(invitingUser, invitedUser, roomId);
     }
-
 }

--- a/src/main/resources/templates/chat/inviteList.html
+++ b/src/main/resources/templates/chat/inviteList.html
@@ -1,5 +1,4 @@
 <html layout:decorate="~{common/layout.html}" xmlns:layout="">
-
 <head>
   <title>유저 목록</title>
   <style>
@@ -28,7 +27,7 @@
         <td th:text="${user.id}"></td>
         <td th:text="${user.username}"></td>
         <td><a th:href="@{/chat/{roomId}/inviteUser/{userId}(roomId=${chatRoom.id}, userId=${user.id})}"
-               class="btn btn-sm btn-outline" th:classappend="${!chatRoom.modifyUnlocked ? 'btn-disabled' : ''}">초대</a></td>
+               class="btn btn-sm btn-outline">초대</a></td>
       </tr>
       </tbody>
     </table>


### PR DESCRIPTION
- [x] notification에 중복된 초대가 있을 경우 DB에서 save 안되도록

---

기존 시간 쿨타임을 주지 않고 notification에 invitingUser, invitedUser, roomId가 일치하는 정보가 있으면 DB에 중복으로 저장되지 않게 하였습니다.