### PR TITLE
Feature/89 매칭 파트너 부분 구현

### DIFF
--- a/src/main/java/com/ll/TeamSteam/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/chatRoom/service/ChatRoomService.java
@@ -126,11 +126,10 @@ public class ChatRoomService {
      * 채팅방 삭제
      */
     @Transactional
-    // @CacheEvict(value = "chatroom", allEntries=true)
     public void remove(Long roomId, Long OwnerId) {
         User owner = userService.findByIdElseThrow(OwnerId);
         log.info("roomId = {}", roomId);
-        log.info("OnwerId = {}", owner.getId());
+        log.info("OwnerId = {}", owner.getId());
 
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));

--- a/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
@@ -219,7 +219,17 @@ public class MatchingController {
     public String addPartner(@PathVariable Long matchingId, @AuthenticationPrincipal SecurityUser user){
         Matching matching = matchingService.findById(matchingId).orElseThrow();
 
+        // true 면 matching partner에 저장되어있고, false 면 없음
+        boolean alreadyWithPartner = matchingPartnerService.isDuplicatedMatchingPartner(matching.getId(), user.getId());
+
+        // 이미 저장된 사람은 중복 저장되지 않도록 처리
+        if (alreadyWithPartner) {
+             throw new IllegalArgumentException("너 이미 참여중이야");
+        }
+
         matchingPartnerService.addPartner(matching.getId(), user.getId());
+
+        // TODO: 매칭 생성한 사람은 매칭 파트너에 바로 저장되게
 
         return String.format("redirect:/match/detail/%d", matchingId);
     }

--- a/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
@@ -118,7 +118,7 @@ public class MatchingController {
 
 
         // 서비스에서 추가 기능 구현
-        Matching createRsData = matchingService.create(
+        Matching matching = matchingService.create(
                 user1,
                 createForm.getTitle(),
                 createForm.getContent(),
@@ -131,13 +131,15 @@ public class MatchingController {
         );
 
         // 매칭 등록 실패 시
-        if (createRsData == null) {
+        if (matching == null) {
             throw new IllegalArgumentException("게시글이 작성되지 않았습니다.");
             // return "match/create";
         }
 
+        log.info("createRsData.getId = {}", matching.getId());
 
-        chatRoomService.createAndConnect(createForm.getTitle(), createRsData, user.getId());
+        matchingPartnerService.addPartner(matching.getId(), user1.getId());
+        chatRoomService.createAndConnect(createForm.getTitle(), matching, user.getId());
 
         // 등록 게시글 작성 후 매칭 목록 페이지로 이동
         return rq.redirectWithMsg("/match/list", "매칭이 게시글이 생성되었습니다.");
@@ -228,8 +230,6 @@ public class MatchingController {
         }
 
         matchingPartnerService.addPartner(matching.getId(), user.getId());
-
-        // TODO: 매칭 생성한 사람은 매칭 파트너에 바로 저장되게
 
         return String.format("redirect:/match/detail/%d", matchingId);
     }

--- a/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
@@ -233,4 +233,23 @@ public class MatchingController {
 
         return String.format("redirect:/match/detail/%d", matchingId);
     }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/detail/{matchingId}/moveChatRoom")
+    public String moveChatRoom(@PathVariable Long matchingId, @AuthenticationPrincipal SecurityUser user){
+        Matching matching = matchingService.findById(matchingId).orElseThrow();
+
+        // true 면 matching partner에 저장되어있고, false 면 없음
+        boolean alreadyWithPartner = matchingPartnerService.isDuplicatedMatchingPartner(matching.getId(), user.getId());
+
+        if (!alreadyWithPartner) {
+            throw new IllegalArgumentException("너 접근 금지야");
+        }
+
+        matchingPartnerService.updateTrue(matching.getId(), user.getId());
+
+        return String.format("redirect:/chat/rooms/%d", matchingId);
+    }
+
+
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/controller/MatchingPartnerController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/controller/MatchingPartnerController.java
@@ -1,0 +1,9 @@
+package com.ll.TeamSteam.domain.matchingPartner.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MatchingPartnerController {
+}

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/entity/MatchingPartner.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/entity/MatchingPartner.java
@@ -23,4 +23,10 @@ public class MatchingPartner extends BaseEntity {
     private User user;
 
     private boolean inChatRoomTrueFalse;
+
+    public void updateInChatRoomTrueFalse(boolean inChatRoomTrueFalse){
+        this.inChatRoomTrueFalse = inChatRoomTrueFalse;
+    }
+
+
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/entity/MatchingPartner.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/entity/MatchingPartner.java
@@ -1,28 +1,26 @@
-package com.ll.TeamSteam.domain.recentlyUser.entity;
+package com.ll.TeamSteam.domain.matchingPartner.entity;
 
-
-import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
+import com.ll.TeamSteam.domain.matching.entity.Matching;
 import com.ll.TeamSteam.domain.user.entity.User;
 import com.ll.TeamSteam.global.baseEntity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import static jakarta.persistence.FetchType.LAZY;
-
 @Entity
 @Getter
 @NoArgsConstructor
 @SuperBuilder
-public class RecentlyUser extends BaseEntity {
+public class MatchingPartner extends BaseEntity {
 
-    String username;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Matching matching;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ManyToOne(fetch = LAZY)
-    private MatchingPartner matchingPartner;
+    private boolean inChatRoomTrueFalse;
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
@@ -1,0 +1,7 @@
+package com.ll.TeamSteam.domain.matchingPartner.repository;
+
+import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingPartnerRepository extends JpaRepository<MatchingPartner, Long> {
+}

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
@@ -1,7 +1,10 @@
 package com.ll.TeamSteam.domain.matchingPartner.repository;
 
+import com.ll.TeamSteam.domain.matching.entity.Matching;
 import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
+import com.ll.TeamSteam.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchingPartnerRepository extends JpaRepository<MatchingPartner, Long> {
+    boolean existsByMatchingAndUser(Matching matching, User user);
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/repository/MatchingPartnerRepository.java
@@ -5,6 +5,10 @@ import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
 import com.ll.TeamSteam.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MatchingPartnerRepository extends JpaRepository<MatchingPartner, Long> {
     boolean existsByMatchingAndUser(Matching matching, User user);
+
+    Optional<MatchingPartner> findByMatchingAndUser(Matching matching, User user);
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
@@ -30,4 +30,16 @@ public class MatchingPartnerService {
 
         matchingPartnerRepository.save(matchingPartner);
     }
+
+    // 검증 로직
+    public boolean isDuplicatedMatchingPartner(Long matchingId, Long currentUserId) {
+        User user = userService.findByIdElseThrow(currentUserId);
+        Matching matching = matchingService.findById(matchingId).orElseThrow();
+
+        if (matching.getId() == null) {
+            throw new IllegalArgumentException("매칭이 존재하지 않음");
+        }
+
+        return matchingPartnerRepository.existsByMatchingAndUser(matching, user);
+    }
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
@@ -42,4 +42,30 @@ public class MatchingPartnerService {
 
         return matchingPartnerRepository.existsByMatchingAndUser(matching, user);
     }
+
+    @Transactional
+    public void updateTrue(Long matchingId, Long currentUserId) {
+        User user = userService.findByIdElseThrow(currentUserId);
+        Matching matching = matchingService.findById(matchingId).orElseThrow();
+
+        if (matching.getId() == null) {
+            throw new IllegalArgumentException("매칭이 존재하지 않음");
+        }
+
+//        MatchingPartner.builder()
+//                .user(user)
+//                .matching(matching)
+//                .inChatRoomTrueFalse(true)
+//                .build();
+
+        MatchingPartner matchingPartner = matchingPartnerRepository.findByMatchingAndUser(matching, user)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 파트너를 찾을 수 없어"));
+
+        matchingPartner.updateInChatRoomTrueFalse(true);
+
+
+    }
+
+
+
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
@@ -1,0 +1,33 @@
+package com.ll.TeamSteam.domain.matchingPartner.service;
+
+import com.ll.TeamSteam.domain.matching.entity.Matching;
+import com.ll.TeamSteam.domain.matching.service.MatchingService;
+import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
+import com.ll.TeamSteam.domain.matchingPartner.repository.MatchingPartnerRepository;
+import com.ll.TeamSteam.domain.user.entity.User;
+import com.ll.TeamSteam.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingPartnerService {
+    private final MatchingPartnerRepository matchingPartnerRepository;
+    private final UserService userService;
+    private final MatchingService matchingService;
+
+    @Transactional
+    public void addPartner(Long matchingId, Long currentUserId) {
+        User user = userService.findByIdElseThrow(currentUserId);
+        Matching matching = matchingService.findById(matchingId).orElseThrow();
+
+        MatchingPartner matchingPartner = MatchingPartner.builder()
+                .matching(matching)
+                .user(user)
+                .inChatRoomTrueFalse(false)
+                .build();
+
+        matchingPartnerRepository.save(matchingPartner);
+    }
+}

--- a/src/main/java/com/ll/TeamSteam/domain/user/entity/User.java
+++ b/src/main/java/com/ll/TeamSteam/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.ll.TeamSteam.domain.user.entity;
 
 import com.ll.TeamSteam.domain.friend.entity.Friend;
 import com.ll.TeamSteam.domain.matching.entity.Matching;
+import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
 import com.ll.TeamSteam.domain.steam.entity.SteamGameLibrary;
 import com.ll.TeamSteam.domain.userTag.UserTag;
 import com.ll.TeamSteam.global.baseEntity.BaseEntity;
@@ -52,6 +53,9 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Friend> friendList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<MatchingPartner> matchingPartners;
 
 
 

--- a/src/main/java/com/ll/TeamSteam/global/baseEntity/BaseEntity.java
+++ b/src/main/java/com/ll/TeamSteam/global/baseEntity/BaseEntity.java
@@ -31,4 +31,5 @@ public abstract class BaseEntity {
     private LocalDateTime createDate;
     @LastModifiedDate
     private LocalDateTime modifyDate;
+
 }

--- a/src/main/resources/templates/matching/create.html
+++ b/src/main/resources/templates/matching/create.html
@@ -4,7 +4,7 @@
     <title>매칭 등록</title>
     <style>
         label {
-            color:white;
+            color: white;
         }
 
         input[type="text"], textarea {
@@ -17,8 +17,8 @@
             color: #1F2227;
         }
 
-        select {
-            color: #1F2227;
+        div > select {
+            color: black;
         }
     </style>
 </head>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -47,14 +47,10 @@
 </div>
 
 <div>
-    <button class="btn">
-        <a th:href="@{|/match/detail/${matching.getId()}/addPartner|}">참여하기</a>
-        <!-- 매칭 상세 페이지 redirect 되게 URL 바꾸기 -->
-    </button>
-    <button class="btn">
-        <a th:href="@{|/chat/rooms/${matching.chatRoom.id}|}">채팅 참여하기</a>
-        <!-- 만약 user가 matchingPartner면 해당 버튼 보이게 하기 -->
-    </button>
+    <a class="!bg-black p-3 text-white hover:cursor-pointer" th:href="@{|/match/detail/${matching.getId()}/addPartner|}">참여하기</a>
+    <!-- 매칭 상세 페이지 redirect 되게 URL 바꾸기 -->
+    <a class="!bg-black p-3 text-white hover:cursor-pointer" th:href="@{|/chat/rooms/${matching.chatRoom.id}|}">채팅 참여하기</a>
+    <!-- 만약 user가 matchingPartner면 해당 버튼 보이게 하기 -->
 </div>
 </main>
 </body>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -48,7 +48,12 @@
 
 <div>
     <button class="btn">
-        <a th:href="@{|/chat/rooms/${matching.chatRoom.id}|}">참여하기</a>
+        <a th:href="@{|/match/detail/${matching.getId()}/addPartner|}">참여하기</a>
+        <!-- 매칭 상세 페이지 redirect 되게 URL 바꾸기 -->
+    </button>
+    <button class="btn">
+        <a th:href="@{|/chat/rooms/${matching.chatRoom.id}|}">채팅 참여하기</a>
+        <!-- 만약 user가 matchingPartner면 해당 버튼 보이게 하기 -->
     </button>
 </div>
 </main>

--- a/src/main/resources/templates/matching/modify.html
+++ b/src/main/resources/templates/matching/modify.html
@@ -4,7 +4,7 @@
     <title>매칭 수정</title>
     <style>
         label {
-            color:white;
+            color: white;
         }
 
         input[type="text"], textarea {
@@ -17,8 +17,8 @@
             color: #1F2227;
         }
 
-        select {
-            color: #1F2227;
+        div > select {
+            color: black;
         }
     </style>
 </head>


### PR DESCRIPTION
**'참여하기' 버튼 클릭 시**
- [ ] 다른 매칭 파트너의 미니 프로필이 보이는 매칭 상세 페이지로 리다이렉트
- [ ] '참여하기' 버튼이 '채팅 참여하기' 버튼으로 변경
- [ ] '참여하기' 버튼 클릭 시 매칭 파트너에 해당 유저의 정보 저장
- [ ] '매칭취소' 버튼 추가
- [ ] '채팅 참여하기' 버튼 클릭 시 해당 매칭의 채팅방으로 이동
- [ ] 매칭 파트너 중 채팅에 참여한 유저는 최근 매칭 유저(recently user)에 저장