### PR TITLE
design : 프로필 UI 수정, 장르태그 모두 추가

### DIFF
--- a/spy.log
+++ b/spy.log
@@ -1,0 +1,1 @@
+1688659998208|2|rollback|connection 16|url jdbc:mariadb://localhost/TeamSteam?user=root||

--- a/spy.log
+++ b/spy.log
@@ -1,1 +1,0 @@
-1688659998208|2|rollback|connection 16|url jdbc:mariadb://localhost/TeamSteam?user=root||

--- a/src/main/java/com/ll/TeamSteam/domain/steam/service/SteamService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/steam/service/SteamService.java
@@ -54,6 +54,9 @@ public class SteamService {
     public RsData<List<SteamGameLibrary>> getUserGameList(String steamId) throws ParseException {
         String url = "http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={apiKey}&steamid={steam_id}" +
             "&include_appinfo=true&format=json";
+        // 같이 시도해볼것
+        //"http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={apiKey}&steamid={steam_id}" +
+        // "&include_appinfo=true&include_played_free_games=true&format=json"
 
         UriComponents builder = UriComponentsBuilder
             .fromHttpUrl(url)

--- a/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
@@ -273,7 +273,8 @@ public class UserController {
 //    }
 
     @PostMapping("/user/profile/editprofile")
-    public String editProfile(){
+    public String editProfile(Model model){
+        model.addAttribute("genreTags",GenreTagType.values());
         return "user/createGenre";
     }
 

--- a/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
@@ -200,7 +200,8 @@ public class UserController {
     }
 
     @GetMapping("user/createGenre")
-    public String test(){
+    public String createGenre(Model model){
+        model.addAttribute("genreTags",GenreTagType.values());
         return "user/createGenre";
     }
 

--- a/src/main/resources/templates/user/createGenre.html
+++ b/src/main/resources/templates/user/createGenre.html
@@ -15,30 +15,14 @@
         여자
     </label>
     <br><br>
-    <label>
-        <input type="checkbox" name="gameGenre" value="일인칭슈팅">
-        일인칭슈팅
-    </label>
-    <br>
-    <label>
-        <input type="checkbox" name="gameGenre" value="삼인칭슈팅">
-        삼인칭슈팅
-    </label>
-    <br>
-    <label>
-        <input type="checkbox" name="gameGenre" value="핵앤슬래시">
-        핵앤슬래시
-    </label>
-    <br>
-    <label>
-        <input type="checkbox" name="gameGenre" value="로그라이크">
-        로그라이크
-    </label>
-    <br>
-    <label>
-        <input type="checkbox" name="gameGenre" value="낚시">
-        낚시
-    </label>
+
+    <th:block th:each="genreTag : ${genreTags}">
+        <label>
+            <input type="checkbox" name="gameGenre" th:value="${genreTag}" th:text="${genreTag}">
+        </label>
+        <br>
+    </th:block>
+
     <br><br>
     <input type="submit" value="제출">
 </form>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -46,33 +46,40 @@
 </head>
 <body>
 <main layout:fragment="main">
-    <div class="card lg:card-side bg-base-100 shadow-xl custom-card">
-        <figure class="ml-4">
-            <img th:src="${targetUser.getAvatar()}" class="w-48 h-48">
+    <div class="card lg:card-side bg-base-100 shadow-xl custom-card" style="height: 400px; overflow: auto;">
+        <figure class="ml-4" style="width: 150px;">
+            <div class="w-48 h-48">
+                <img th:src="${targetUser.getAvatar()}" class="w-full h-full">
+            </div>
         </figure>
         <div class="card-body">
             <h1 class="my-4 text-3xl" th:text="${targetUser.getUsername()}" style="color: #dddddd;"></h1>
-            <div class="ml-4 pt-4">
-                <p class="mb-2">매너온도:</p>
+            <div class="ml-4" style="width: calc(100% - 150px);">
+                        <div class="flex pt-4">
+                        <div class="table-cell">
+                            <div class="flex flex-wrap">
+                                <div th:if="${!targetUser.getUserTag().getGameTag().isEmpty()}" th:each="targetUserGameTag : ${targetUser.getUserTag().getGameTag()}" class="badge bg-sky-500 badge-accent inline max-w-[10rem]">
+                                    <span th:text="${targetUserGameTag.getName()}"></span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="table-cell">
+                            <div class="flex flex-wrap">
+                                <div th:if="${!targetUser.getUserTag().getGenreTag().isEmpty()}" th:each="targetUserGenreTag : ${targetUser.getUserTag().getGenreTag()}" class="badge bg-green-500 badge-accent inline max-w-[10rem]">
+                                    <span th:text="${targetUserGenreTag.getGenre()}"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <div class="pt-4">
+                <p class="mb-2">매너온도:<span th:text="${targetUser.getTemperature()}"></span></p>
                 <progress class="progress progress-accent w-56 progress-custom" th:value="${targetUser.getTemperature()}" max="100">
                 </progress>
+                </div>
             </div>
-            <div class="flex flex-col items-center">
-                <table>
-                    <tr th:if="${!targetUser.getUserTag().getGameTag.isEmpty()}" th:each="targetUserGameTag : ${targetUser.getUserTag().gameTag}">
-                        <td>
-                            <div class="badge bg-sky-500 badge-accent break-words max-w-[10rem]" th:text="${targetUserGameTag.getName()}"></div>
-                        </td>
-                    </tr>
-                    <tr th:if="${!targetUser.getUserTag().getGenreTag().isEmpty()}" th:each="targetUserGenreTag : ${targetUser.getUserTag().genreTag}">
-                        <td>
-                            <div class="badge bg-green-500 badge-accent break-words max-w-[10rem]" th:text="${targetUserGenreTag.getGenre()}"></div>
-                        </td>
-                    </tr>
-                </table>
 <!--                <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${1}}" style="color: #dddddd">좋아요</a>-->
 <!--                <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${0}}" style="color: #dddddd">싫어요</a>-->
-            </div>
+
             <div class="card-actions justify-end">
                 <form th:action="@{/user/profile/editprofile}" method="post">
                     <button th:if="${loginedId == targetUser.getId()}" type="submit" class="btn btn-primary">Edit Tag</button>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -32,23 +32,46 @@
             border:0px;
 
         }
+        .custom-card2{
+            background-color: #202d3e;
+            border:0px;
+
+        }
+        .progress-custom {
+            background-image: linear-gradient(90deg, #1c92d2 0%,#f2fcfe 100%);
+            height: 30px;
+        }
+
     </style>
 </head>
 <body>
 <main layout:fragment="main">
     <div class="card lg:card-side bg-base-100 shadow-xl custom-card">
-        <figure><img th:src="${targetUser.getAvatar()}"  class="w-48 h-48"></figure>
+        <figure class="ml-4">
+            <img th:src="${targetUser.getAvatar()}" class="w-48 h-48">
+        </figure>
         <div class="card-body">
-            <h1 class="my-4" th:text="${targetUser.getUsername()} + '의 프로필'" style="color: #dddddd;"></h1>
+            <h1 class="my-4 text-3xl" th:text="${targetUser.getUsername()}" style="color: #dddddd;"></h1>
+            <div class="ml-4 pt-4">
+                <p class="mb-2">매너온도:</p>
+                <progress class="progress progress-accent w-56 progress-custom" th:value="${targetUser.getTemperature()}" max="100">
+                </progress>
+            </div>
             <div class="flex flex-col items-center">
                 <table>
                     <tr th:if="${!targetUser.getUserTag().getGameTag.isEmpty()}" th:each="targetUserGameTag : ${targetUser.getUserTag().gameTag}">
-                        <td><div class="badge bg-sky-500 badge-accent" th:text="${targetUserGameTag.getName()}"></div></td>
+                        <td>
+                            <div class="badge bg-sky-500 badge-accent break-words max-w-[10rem]" th:text="${targetUserGameTag.getName()}"></div>
+                        </td>
                     </tr>
                     <tr th:if="${!targetUser.getUserTag().getGenreTag().isEmpty()}" th:each="targetUserGenreTag : ${targetUser.getUserTag().genreTag}">
-                        <td><div class="badge bg-green-500 badge-accent" th:text="${targetUserGenreTag.getGenre()}"></div></td>
+                        <td>
+                            <div class="badge bg-green-500 badge-accent break-words max-w-[10rem]" th:text="${targetUserGenreTag.getGenre()}"></div>
+                        </td>
                     </tr>
                 </table>
+<!--                <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${1}}" style="color: #dddddd">좋아요</a>-->
+<!--                <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${0}}" style="color: #dddddd">싫어요</a>-->
             </div>
             <div class="card-actions justify-end">
                 <form th:action="@{/user/profile/editprofile}" method="post">
@@ -60,40 +83,49 @@
             </div>
         </div>
     </div>
-<div class ="container">
-    <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${1}}" style="color: #dddddd">좋아요</a>
-    <a th:href="@{'/user/profile/' + ${targetUser.getId()} +'/'+ ${0}}" style="color: #dddddd">싫어요</a>
-    <div><progress class="progress progress-accent w-56" th:value="${targetUser.getTemperature()}" max="100"></progress></div>
-<!--    <div th:text="${targetUser.getTemperature()}"></div>-->
-
     <div th:if="${loginedId == targetUser.getId()}">
-        <tr th:each="friend: ${friendsList}">
+        <div class="flex justify-end">
+            <div>
+                <h2 class="text-xl font-semibold mb-4">친구 목록</h2>
 
-            <td th:text="${friend.getFriend().getId()}"></td>
-            <td th:text="${friend.getFriend().getUsername()}"></td>
-            <td>
-                <img th:src="${friend.getFriend().getAvatar()}">
-            </td>
-        </tr>
+                <th:block th:if="${!friendsList.isEmpty()}">
+                    <table class="table-auto">
+                        <thead>
+                        <tr>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:each="friend: ${friendsList}">
+                            <td th:text="${friend.getFriend().getId()}"></td>
+                            <td th:text="${friend.getFriend().getUsername()}"></td>
+                            <td>
+                                <img th:src="${friend.getFriend().getAvatar()}" class="w-8 h-8 rounded-full">
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </th:block>
+                <th:block th:if="${friendsList.isEmpty()}">
+                    <p class="text-gray-500">친구를 추가해주세요.</p>
+                </th:block>
+            </div>
+        </div>
     </div>
-    <table class="table table-striped" style="margin: 0 auto;">
-        <thead>
-        <tr>
-            <th>게임 이름</th>
-            <th>이미지</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="game : ${gameList}">
-            <td th:text="${game.name}"></td>
-            <td>
-                <img th:src="@{'https://steamcdn-a.akamaihd.net/steam/apps/' + ${game.appid} + '/header.jpg'}"
-                     alt="게임 이미지" width="200" height="auto"/>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
+
+    <div class="card lg:card-side bg-base-100 shadow-xl custom-card2 ">
+        <div class="card-body">
+            <h2 class="card-title" style="color: #dddddd;">Game Library</h2>
+            <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+                <div th:each="game : ${gameList}" class="card">
+                    <img th:src="@{'https://steamcdn-a.akamaihd.net/steam/apps/' + ${game.appid} + '/header.jpg'}"
+                         alt="게임 이미지" class="card-img-top">
+                    <div class="card-body">
+                        <h5 class="card-title" th:text="${game.name}"></h5>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </main>
 </body>
 </html>


### PR DESCRIPTION
close #96 

## ✅DONE
- 프로필 UI 수정
- 장르태그 목록 모두 추가
-  태그 재선택 버그수정
-  태그를 많이 선택했을때, 글자깨짐 및 카드 크기 변화 수정


## ✅TODO
- 태그 선택 UI 수정



## ✅RESULT
수정 전:
![화면 캡처 2023-07-07 011429](https://github.com/TeamSteam-11/TeamSteam/assets/122251142/f3912391-c6d6-4730-a199-0dbc2b6f9d94)

수정 후:
![image](https://github.com/TeamSteam-11/TeamSteam/assets/122251142/8128c27e-9054-4f4e-befa-a270236df29a)

