### PR TITLE
프로필 페이지, 장르태그 페이지 UI수정, 검증추가

### DIFF
--- a/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/user/controller/UserController.java
@@ -173,8 +173,15 @@ public class UserController {
     }
 
     @PostMapping(value = "/user/createGameTag/save-gametag")
-    public String saveGameTags(@RequestParam("selectedGames") List<Integer> selectedGames,
+    public String saveGameTags(@RequestParam(value = "selectedGames", required = false) List<Integer> selectedGames,
                                @AuthenticationPrincipal SecurityUser user) {
+
+        /**
+         * TODO 게임목록을 1개도 못불러왔을 때 안내페이지로 이동하게 만들기 // 프로필설정을 바꿔야한다던가, 게임이 0개라고 안내
+         */
+
+        //게임목록에서 아무것도 체크하지 않았을 시 리다이렉트
+        if(selectedGames == null) return "redirect:/user/createGameTag";
 
         String steamId = user.getSteamId();
         userService.saveSelectedGames(selectedGames, steamId);
@@ -205,9 +212,14 @@ public class UserController {
     }
 
     @PostMapping("/user/createGenre")
-    public String genreFormPost(@RequestParam String gender, @RequestParam("gameGenre") String[] gameGenres,
+    public String genreFormPost(@RequestParam(required = false) String gender, @RequestParam(value = "gameGenre", required = false) String[] gameGenres,
                                 @AuthenticationPrincipal SecurityUser user) {
         Long id = user.getId();
+
+        if(gender == null || gameGenres == null){
+            return "redirect:/user/createGenre";
+            //둘중 하나라도 비어있을 시 리다이렉트 에러문구 출력이 가장좋음
+        }
 
         // GenreTagType enum으로 변환하여 리스트로 저장
         List<GenreTagType> genreTagTypes = Arrays.stream(gameGenres)

--- a/src/main/resources/templates/user/createGenre.html
+++ b/src/main/resources/templates/user/createGenre.html
@@ -1,11 +1,11 @@
 <html layout:decorate="~{common/layout.html}">
-<!DOCTYPE html>
-<html>
 <head>
     <title>폼 예시</title>
+
     <style>
-        .selected {
-            background-color: yellow;
+        .badge.selected {
+            background-color: #22f1a3; /* 변경하고자 하는 배경색 */
+            border-color: #22f1a3;
         }
     </style>
 </head>
@@ -22,39 +22,28 @@
         여자
     </label>
     <br><br>
-    <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap">
-        <th:block th:each="genreTag : ${genreTags}" >
-            <label class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3" onclick="toggleCheckbox(this)">
-                <input type="checkbox" name="gameGenre" th:value="${genreTag}" th:text="${genreTag}" style="display: none">
+    <hr3>장르 태그를 선택해주세요</hr3>
+    <hr style="border-color: #dddddd; border-width: 2px">
+    <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; margin-top:3px">
+        <th:block th:each="genreTag : ${genreTags}">
+            <label class="badge bg-green-800 badge-accent inline max-w-[10rem] ml-3 hover:cursor-pointer">
+                <input type="checkbox" name="gameGenre" th:value="${genreTag}" th:text="${genreTag}" style="display: none" onchange="toggleCheckbox(this)">
             </label>
             <br>
         </th:block>
     </div>
-<!--    <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap">-->
-<!--    <th:block th:each="genreTag : ${genreTags}" >-->
-<!--        <label class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3" th:text="${genreTag}">-->
-<!--            <div class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3"  th:text="${genreTag}" onclick="toggleCheckbox(this)">-->
-<!--            <input type="checkbox" name="gameGenre" th:value="${genreTag}" style="display: none">-->
-<!--            <span>{{genreTag}}</span>-->
-<!--            </div>-->
-<!--        </label>-->
-<!--        <br>-->
-<!--    </th:block>-->
-<!--    </div>-->
 
     <br><br>
     <button class="btn btn-accent">제출</button>
     <input type="submit" value="">
 </form>
-</main>
-<script>
-    function toggleCheckbox(genreTag) {
-        var checkbox = document.getElementById('checkbox_' + genreTag);
-        checkbox.checked = !checkbox.checked;
-        var label = document.querySelector('label[for="checkbox_' + genreTag + '"]');
-        label.classList.toggle('selected');
-    }
-</script>
 
+    <script>
+        function toggleCheckbox(checkbox) {
+            var label = checkbox.parentNode;
+            label.classList.toggle("selected");
+        }
+    </script>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/user/createGenre.html
+++ b/src/main/resources/templates/user/createGenre.html
@@ -1,9 +1,16 @@
+<html layout:decorate="~{common/layout.html}">
 <!DOCTYPE html>
 <html>
 <head>
     <title>폼 예시</title>
+    <style>
+        .selected {
+            background-color: yellow;
+        }
+    </style>
 </head>
 <body>
+<main layout:fragment="main">
 <form th:action="@{/user/createGenre}" method="post">
     <label>
         <input type="radio" name="gender" value="남성">
@@ -15,16 +22,39 @@
         여자
     </label>
     <br><br>
-
-    <th:block th:each="genreTag : ${genreTags}">
-        <label>
-            <input type="checkbox" name="gameGenre" th:value="${genreTag}" th:text="${genreTag}">
-        </label>
-        <br>
-    </th:block>
+    <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap">
+        <th:block th:each="genreTag : ${genreTags}" >
+            <label class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3" onclick="toggleCheckbox(this)">
+                <input type="checkbox" name="gameGenre" th:value="${genreTag}" th:text="${genreTag}" style="display: none">
+            </label>
+            <br>
+        </th:block>
+    </div>
+<!--    <div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap">-->
+<!--    <th:block th:each="genreTag : ${genreTags}" >-->
+<!--        <label class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3" th:text="${genreTag}">-->
+<!--            <div class="badge bg-green-500 badge-accent inline max-w-[10rem] ml-3"  th:text="${genreTag}" onclick="toggleCheckbox(this)">-->
+<!--            <input type="checkbox" name="gameGenre" th:value="${genreTag}" style="display: none">-->
+<!--            <span>{{genreTag}}</span>-->
+<!--            </div>-->
+<!--        </label>-->
+<!--        <br>-->
+<!--    </th:block>-->
+<!--    </div>-->
 
     <br><br>
-    <input type="submit" value="제출">
+    <button class="btn btn-accent">제출</button>
+    <input type="submit" value="">
 </form>
+</main>
+<script>
+    function toggleCheckbox(genreTag) {
+        var checkbox = document.getElementById('checkbox_' + genreTag);
+        checkbox.checked = !checkbox.checked;
+        var label = document.querySelector('label[for="checkbox_' + genreTag + '"]');
+        label.classList.toggle('selected');
+    }
+</script>
+
 </body>
 </html>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -44,16 +44,18 @@
 </head>
 <body>
 <main layout:fragment="main">
-    <div class="card lg:card-side bg-base-100 shadow-xl custom-card" style="height: 400px; overflow: auto;">
-        <figure class="ml-4" style="width: 150px;">
+    <div class="card lg:card-side bg-base-100 shadow-xl custom-card" style="height: 400px; overflow: auto; display: flex;">
+        <div>
+        <figure class="ml-8 mt-8" style="width: 150px;">
             <div class="w-48 h-48">
-                <img th:src="${targetUser.getAvatar()}" class="w-full h-full">
+                <img th:src="${targetUser.getAvatar()}" class="w-full h-full object-cover">
             </div>
         </figure>
-        <div class="card-body">
-            <h1 class="my-4 text-3xl" th:text="${targetUser.getUsername()}" style="color: #dddddd;"></h1>
+        </div>
+        <div class="card-body" style="display: flex; margin-top: 1px;">
+            <h1 class="my-2 text-3xl" th:text="${targetUser.getUsername()}" style="color: #dddddd;"></h1>
             <div class="ml-4" style="width: calc(100% - 150px);">
-                        <div class="flex pt-4">
+                        <div class="flex pt-4" style="display: flex; flex-direction: column">
                         <div class="table-cell">
                             <div class="flex flex-wrap">
                                 <div th:if="${!targetUser.getUserTag().getGameTag().isEmpty()}" th:each="targetUserGameTag : ${targetUser.getUserTag().getGameTag()}" class="badge bg-sky-500 badge-accent inline max-w-[10rem]">


### PR DESCRIPTION
Close #114 

- [x] 프로필 페이지 UI (게임태그, 장르태그 줄바꿈)
- [x] 장르태그 페이지 UI
- [x] 태그 저장하는 곳에서 성별, 장르태그, 게임태그 중 하나라도 입력이 안될 시 리다이렉트

-------
- 프로필 페이지 : 게임태그랑 장르태그가 좀 더 명확하게 구분되도록 각 태그별 줄바꿈
- 장르태그 버튼형식 UI

리다이렉트할 때 추가로 문구 출력하면 좋을 것 같습니다 다음번 작업 때 시도해볼게요

![image](https://github.com/TeamSteam-11/TeamSteam/assets/75903442/6b970f7a-3703-49e0-9f1a-a92d259f374a)

![image](https://github.com/TeamSteam-11/TeamSteam/assets/75903442/fbd805e0-228d-4edf-b1f2-31ecf3338dd6)
