### PR TITLE
feat/157 부정적인 생성 시 error페이지로 이동

### DIFF
--- a/src/main/java/com/ll/TeamSteam/domain/home/HomeController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/home/HomeController.java
@@ -36,4 +36,12 @@ public class HomeController {
 
         return "main/home";
     }
+
+    @GetMapping("/main/error")
+    public String error(){
+        // 에러 처리 페이지
+
+        return "common/error";
+    }
+
 }

--- a/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
@@ -3,6 +3,7 @@ package com.ll.TeamSteam.domain.matching.controller;
 import com.ll.TeamSteam.domain.chatRoom.entity.ChatRoom;
 import com.ll.TeamSteam.domain.chatRoom.service.ChatRoomService;
 import com.ll.TeamSteam.domain.matching.entity.Matching;
+import com.ll.TeamSteam.domain.matching.exception.MatchingPartnerNotFoundException;
 import com.ll.TeamSteam.domain.matching.service.MatchingService;
 import com.ll.TeamSteam.domain.matchingPartner.service.MatchingPartnerService;
 import com.ll.TeamSteam.domain.matchingTag.entity.GenreTagType;
@@ -150,8 +151,8 @@ public class MatchingController {
 
         // 매칭 등록 실패 시
         if (matching == null) {
-            throw new IllegalArgumentException("게시글이 작성되지 않았습니다.");
-            // return "match/create";
+//            throw new IllegalArgumentException("게시글이 작성되지 않았습니다.");
+            return "redirect:/main/error";
         }
 
         log.info("createRsData.getId = {}", matching.getId());
@@ -267,7 +268,8 @@ public class MatchingController {
 
         // 이미 저장된 사람은 중복 저장되지 않도록 처리
         if (alreadyWithPartner) {
-             throw new IllegalArgumentException("너 이미 매칭파트너에 참여중이야");
+//             throw new IllegalArgumentException("너 이미 매칭파트너에 참여중이야");
+            return "redirect:/main/error";
         }
 
         ChatRoom chatRoom = chatRoomService.findById(matchingId);
@@ -296,7 +298,13 @@ public class MatchingController {
         boolean alreadyWithPartner = matchingPartnerService.isDuplicatedMatchingPartner(matching.getId(), user.getId());
 
         if (!alreadyWithPartner) {
-            throw new IllegalArgumentException("너 지금 매칭파트너에 등록이 안되어있어, 우선 매칭파트너부터 등록해");
+            return "redirect:/main/error";
+        }
+
+        try {
+            matchingPartnerService.updateTrue(matching.getId(), user.getId());
+        } catch (MatchingPartnerNotFoundException e) {
+            return "redirect:/main/error";
         }
 
         matchingPartnerService.updateTrue(matching.getId(), user.getId());

--- a/src/main/java/com/ll/TeamSteam/domain/matching/exception/MatchingPartnerNotFoundException.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/exception/MatchingPartnerNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ll.TeamSteam.domain.matching.exception;
+
+public class MatchingPartnerNotFoundException extends IllegalArgumentException {
+    public MatchingPartnerNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ll/TeamSteam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ll/TeamSteam/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.ll.TeamSteam.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.NoSuchElementException;
+
+@Controller
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public String IllegalArgumentException(Exception e, Model model){
+        model.addAttribute("errorMessage",e.getMessage());
+        log.info("e.getMessage = {} ", e.getMessage());
+        return "common/error";
+    }
+
+    @ExceptionHandler(value = NoSuchElementException.class)
+    public String NoSuchElementException(Exception e, Model model){
+        model.addAttribute("errorMessage",e.getMessage());
+        log.info("e.getMessage = {} ", e.getMessage());
+        return "common/error";
+    }
+}


### PR DESCRIPTION
close #157 

- [x] 매칭 파트너를 중복 등록할 경우 error 페이지로 이동하도록
- [x] 매칭 파트너로 등록되지 않은 유저가 방에 입장하려고 할 때 error 페이지로 이동
- [x] chatRoom이 삭제되고 남은 인원들에게 error 페이지 던지기