### PR TITLE
bug/172 방이 존재하지 않을 경우 noChatroomError가 나오도록

### DIFF
--- a/src/main/java/com/ll/TeamSteam/domain/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/chatRoom/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import com.ll.TeamSteam.domain.chatMessage.dto.response.SignalResponse;
 import com.ll.TeamSteam.domain.chatMessage.service.ChatMessageService;
 import com.ll.TeamSteam.domain.chatRoom.dto.ChatRoomDto;
 import com.ll.TeamSteam.domain.chatRoom.entity.ChatRoom;
+import com.ll.TeamSteam.domain.chatRoom.exception.NoChatRoomException;
 import com.ll.TeamSteam.domain.chatRoom.service.ChatRoomService;
 import com.ll.TeamSteam.domain.chatUser.entity.ChatUser;
 import com.ll.TeamSteam.domain.chatUser.service.ChatUserService;

--- a/src/main/java/com/ll/TeamSteam/domain/chatRoom/exception/NoChatRoomException.java
+++ b/src/main/java/com/ll/TeamSteam/domain/chatRoom/exception/NoChatRoomException.java
@@ -1,0 +1,7 @@
+package com.ll.TeamSteam.domain.chatRoom.exception;
+
+public class NoChatRoomException extends RuntimeException{
+    public NoChatRoomException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ll/TeamSteam/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/chatRoom/service/ChatRoomService.java
@@ -4,6 +4,7 @@ import com.ll.TeamSteam.domain.chatMessage.entity.ChatMessage;
 import com.ll.TeamSteam.domain.chatRoom.dto.ChatRoomDto;
 import com.ll.TeamSteam.domain.chatRoom.entity.ChatRoom;
 import com.ll.TeamSteam.domain.chatRoom.exception.KickedUserEnterException;
+import com.ll.TeamSteam.domain.chatRoom.exception.NoChatRoomException;
 import com.ll.TeamSteam.domain.chatRoom.repository.ChatRoomRepository;
 import com.ll.TeamSteam.domain.chatUser.entity.ChatUser;
 import com.ll.TeamSteam.domain.chatUser.entity.ChatUserType;
@@ -33,7 +34,7 @@ import static com.ll.TeamSteam.domain.chatUser.entity.ChatUserType.EXIT;
 import static com.ll.TeamSteam.domain.chatUser.entity.ChatUserType.KICKED;
 
 @Service
-//@Transactional(readOnly = true)
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class ChatRoomService {
@@ -70,7 +71,8 @@ public class ChatRoomService {
     }
 
     public ChatRoom findById(Long roomId) {
-        return chatRoomRepository.findById(roomId).orElseThrow();
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new NoChatRoomException("방이 존재하지 않습니다."));
     }
 
     @Transactional
@@ -167,7 +169,7 @@ public class ChatRoomService {
         log.info("OwnerId = {}", owner.getId());
 
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new NoChatRoomException("존재하지 않는 방입니다."));
 
         if(!chatRoom.getOwner().equals(owner)) {
             throw new IllegalArgumentException("방 삭제 권한이 없습니다.");
@@ -188,7 +190,7 @@ public class ChatRoomService {
     @Transactional
     public void exitChatRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new NoChatRoomException("존재하지 않는 방입니다."));
         log.info("userId = {} ", userId);
 
         // 해당 유저의 ChatUser를 제거합니다.
@@ -232,7 +234,7 @@ public class ChatRoomService {
     @Transactional
     public void kickChatUser(Long roomId, Long chatUserId, SecurityUser user) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new NoChatRoomException("존재하지 않는 방입니다."));
 
         checkOwner(chatRoom, user.getId());
 
@@ -309,7 +311,7 @@ public class ChatRoomService {
     @Transactional
     public RsData<User> inviteUser(Long roomId, SecurityUser user, Long userId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new NoChatRoomException("존재하지 않는 방입니다."));
 
         log.info("chatRoom = {} ", chatRoom);
 
@@ -338,7 +340,7 @@ public class ChatRoomService {
 
     public boolean isDuplicateInvite(Long roomId, Long invitingUserId, Long invitedUserId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new NoChatRoomException("존재하지 않는 방입니다."));
 
         // 현재 로그인된 사용자가 방에 있는지 확인하는 로직
         User invitingUser = userService.findByIdElseThrow(invitingUserId);

--- a/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matching/controller/MatchingController.java
@@ -2,6 +2,7 @@ package com.ll.TeamSteam.domain.matching.controller;
 
 import com.ll.TeamSteam.domain.chatRoom.entity.ChatRoom;
 import com.ll.TeamSteam.domain.chatRoom.exception.KickedUserEnterException;
+import com.ll.TeamSteam.domain.chatRoom.exception.NoChatRoomException;
 import com.ll.TeamSteam.domain.chatRoom.service.ChatRoomService;
 import com.ll.TeamSteam.domain.matching.entity.Matching;
 import com.ll.TeamSteam.domain.matching.exception.MatchingPartnerNotFoundException;
@@ -169,7 +170,8 @@ public class MatchingController {
     @GetMapping("/detail/{matchingId}")
     public String matchingDetail(Model model, @PathVariable Long matchingId) {
 
-        Matching matching = matchingService.findById(matchingId).orElse(null);
+        Matching matching = matchingService.findById(matchingId)
+                .orElseThrow(() -> new NoChatRoomException("현재 존재하지 않는 방입니다."));
 
         boolean alreadyWithPartner = false;
 

--- a/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
+++ b/src/main/java/com/ll/TeamSteam/domain/matchingPartner/service/MatchingPartnerService.java
@@ -2,6 +2,7 @@ package com.ll.TeamSteam.domain.matchingPartner.service;
 
 import java.util.List;
 
+import com.ll.TeamSteam.domain.chatRoom.exception.NoChatRoomException;
 import com.ll.TeamSteam.domain.matching.entity.Matching;
 import com.ll.TeamSteam.domain.matching.service.MatchingService;
 import com.ll.TeamSteam.domain.matchingPartner.entity.MatchingPartner;
@@ -41,7 +42,7 @@ public class MatchingPartnerService {
         Matching matching = matchingService.findById(matchingId).orElseThrow();
 
         if (matching.getId() == null) {
-            throw new IllegalArgumentException("매칭이 존재하지 않음");
+            throw new NoChatRoomException("매칭이 존재하지 않음");
         }
 
         return matchingPartnerRepository.existsByMatchingAndUser(matching, user);
@@ -53,7 +54,7 @@ public class MatchingPartnerService {
         Matching matching = matchingService.findById(matchingId).orElseThrow();
 
         if (matching.getId() == null) {
-            throw new IllegalArgumentException("매칭이 존재하지 않음");
+            throw new NoChatRoomException("매칭이 존재하지 않음");
         }
 
         /**
@@ -79,7 +80,7 @@ public class MatchingPartnerService {
         Matching matching = matchingService.findById(matchingId).orElseThrow();
 
         if (matching.getId() == null) {
-            throw new IllegalArgumentException("매칭이 존재하지 않음");
+            throw new NoChatRoomException("매칭이 존재하지 않음");
         }
 
         MatchingPartner matchingPartner = matchingPartnerRepository.findByMatchingAndUser(matching, user)

--- a/src/main/java/com/ll/TeamSteam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ll/TeamSteam/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ll.TeamSteam.global.error;
 
 import com.ll.TeamSteam.domain.chatRoom.exception.KickedUserEnterException;
+import com.ll.TeamSteam.domain.chatRoom.exception.NoChatRoomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -27,7 +28,7 @@ public class GlobalExceptionHandler {
     public String noSuchElementException(Exception e, Model model){
         model.addAttribute("errorMessage",e.getMessage());
         log.info("e.getMessage = {} ", e.getMessage());
-        return "error/noChatroomError";
+        return "error/commonError";
     }
 
     @ExceptionHandler(value = HttpRequestMethodNotSupportedException.class)
@@ -44,6 +45,7 @@ public class GlobalExceptionHandler {
         return "error/commonError";
     }
 
+    // 커스텀
     @ExceptionHandler(value = KickedUserEnterException.class)
     public String KickedUserEnterException(Exception e, Model model){
         model.addAttribute("errorMessage",e.getMessage());
@@ -56,5 +58,14 @@ public class GlobalExceptionHandler {
         model.addAttribute("errorMessage",e.getMessage());
         log.info("e.getMessage = {} ", e.getMessage());
         return "error/commonError";
+    }
+
+
+    // 커스텀
+    @ExceptionHandler(value = NoChatRoomException.class)
+    public String NoChatRoomException(Exception e, Model model){
+        model.addAttribute("errorMessage",e.getMessage());
+        log.info("e.getMessage = {} ", e.getMessage());
+        return "error/noChatroomError";
     }
 }

--- a/src/main/resources/templates/error/noChatroomError.html
+++ b/src/main/resources/templates/error/noChatroomError.html
@@ -13,7 +13,7 @@
         <img src="https://cdn.jsdelivr.net/gh/LeeYulhee/projectlion_img/teamsteam/NoChatRoom.png" alt="error" class="w-96">
       </div>
       <div class="flex justify-center mt-14 text-3xl">
-        채팅방이 삭제되었습니다😥
+        현재 존재하지 않는 방입니다😥
       </div>
     </div>
 


### PR DESCRIPTION
close #172

- [x] 유저거 앖는 경우에도 "채팅방이 삭제되었습니다" 라고 나오는 error페이지 안나오도록 수정
- [x] NoChatRoomException 추가 하여 매칭, 채팅방이 없을 경우 "현재 방이 존재하지 않습니다" 라고 나오도록 수정