### PR TITLE
TS-58 미니 프로필 태그 개수 5개 이하만 조회 가능

### DIFF
--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -324,19 +324,31 @@
                             <div>
                                 <!--게임 태그-->
                                 <div class="flex flex-wrap">
-                                    <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                         th:each="gameTag, gameTagIndex : ${matchingPartner.getUser().getUserTag().getGameTag()}"
-                                         th:if="${gameTagIndex.size} != 0 and ${gameTagIndex.index} < 5" th:text="${gameTag.getName()}"
-                                         style="background-color: #00a3ff; border-radius: 5px"></div>
+                                    <th:block th:each="gameTag, gameTagIndex : ${matchingPartner.getUser().getUserTag().getGameTag()}">
+                                        <div class="m-1 p-1 text-xs flex items-center justify-center"
+                                             th:if="${gameTagIndex.size} != 0 and ${gameTagIndex.index} < 5"
+                                             th:text="${gameTag.getName()}"
+                                             style="background-color: #00a3ff; border-radius: 5px"></div>
+                                        <div class="m-1 p-1 text-xs flex items-center justify-center"
+                                             th:if="${gameTagIndex.size > 5 and gameTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGameTag()) - 1}"
+                                             style="min-width: 20px; background-color: #00a3ff; border-radius: 5px">...
+                                        </div>
+                                    </th:block>
                                 </div>
                                 <!--게임 태그-->
 
                                 <!--장르 태그-->
                                 <div class="flex flex-wrap">
-                                    <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                         th:each="genreTag, genreTagIndex : ${matchingPartner.getUser().getUserTag().getGenreTag()}"
-                                         th:if="${genreTagIndex.size} != 0 and ${genreTagIndex.index} < 5" th:text="${genreTag.getGenre()}"
-                                         style="background-color: #878787; border-radius: 5px"></div>
+                                    <th:block th:each="genreTag, genreTagIndex : ${matchingPartner.getUser().getUserTag().getGenreTag()}">
+                                        <div class="m-1 p-1 text-xs flex items-center justify-center"
+                                             th:if="${genreTagIndex.size} != 0 and ${genreTagIndex.index} < 5"
+                                             th:text="${genreTag.getGenre()}"
+                                             style="background-color: #878787; border-radius: 5px"></div>
+                                        <div class="m-1 p-1 text-xs flex items-center justify-center"
+                                             th:if="${genreTagIndex.index > 5 and genreTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGenreTag()) - 1}"
+                                             style="min-width: 20px; background-color: #878787; border-radius: 5px">...
+                                        </div>
+                                    </th:block>
                                 </div>
                                 <!--장르 태그 끝-->
                             </div>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -325,9 +325,9 @@
                                 <!--게임 태그-->
                                 <div class="flex flex-wrap">
                                     <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                         th:each="gameTag: ${matchingPartner.getUser().getUserTag().getGameTag()}"
-                                         th:text="${gameTag.getName()}"
-                                         style="min-width: 64px; background-color: #00a3ff; border-radius: 5px">
+                                         th:each="gameTag, gameTagIndex : ${matchingPartner.getUser().getUserTag().getGameTag()}"
+                                         th:if="${gameTagIndex.size} != 0 and ${gameTagIndex.index} < 5" th:text="${gameTag.getName()}"
+                                         style="background-color: #00a3ff; border-radius: 5px">
                                         게임 태그
                                     </div>
                                 </div>
@@ -336,9 +336,9 @@
                                 <!--장르 태그-->
                                 <div class="flex flex-wrap">
                                     <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                         th:each="genreTag: ${matchingPartner.getUser().getUserTag().getGenreTag()}"
-                                         th:text="${genreTag.getGenre()}"
-                                         style="min-width: 64px; background-color: #878787; border-radius: 5px"></div>
+                                         th:each="genreTag, genreTagIndex : ${matchingPartner.getUser().getUserTag().getGenreTag()}"
+                                         th:if="${genreTagIndex.size} != 0 and ${genreTagIndex.index} < 5" th:text="${genreTag.getGenre()}"
+                                         style="background-color: #878787; border-radius: 5px"></div>
                                 </div>
                                 <!--장르 태그 끝-->
                             </div>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -330,7 +330,7 @@
                                              th:text="${gameTag.getName()}"
                                              style="background-color: #00a3ff; border-radius: 5px"></div>
                                         <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                             th:if="${gameTagIndex.size > 5 and gameTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGameTag()) - 1}"
+                                             th:if="${gameTagIndex.size} >= 5 and ${gameTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGameTag()) - 1}"
                                              style="min-width: 20px; background-color: #00a3ff; border-radius: 5px">...
                                         </div>
                                     </th:block>
@@ -345,7 +345,7 @@
                                              th:text="${genreTag.getGenre()}"
                                              style="background-color: #878787; border-radius: 5px"></div>
                                         <div class="m-1 p-1 text-xs flex items-center justify-center"
-                                             th:if="${genreTagIndex.index > 5 and genreTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGenreTag()) - 1}"
+                                             th:if="${genreTagIndex.index} >= 5 and ${genreTagIndex.index == #lists.size(matchingPartner.getUser().getUserTag().getGenreTag()) - 1}"
                                              style="min-width: 20px; background-color: #878787; border-radius: 5px">...
                                         </div>
                                     </th:block>

--- a/src/main/resources/templates/matching/detail.html
+++ b/src/main/resources/templates/matching/detail.html
@@ -327,9 +327,7 @@
                                     <div class="m-1 p-1 text-xs flex items-center justify-center"
                                          th:each="gameTag, gameTagIndex : ${matchingPartner.getUser().getUserTag().getGameTag()}"
                                          th:if="${gameTagIndex.size} != 0 and ${gameTagIndex.index} < 5" th:text="${gameTag.getName()}"
-                                         style="background-color: #00a3ff; border-radius: 5px">
-                                        게임 태그
-                                    </div>
+                                         style="background-color: #00a3ff; border-radius: 5px"></div>
                                 </div>
                                 <!--게임 태그-->
 

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -310,8 +310,8 @@
                                         <div class="flex flex-wrap pt-1" style="display: flex; flex-direction: column">
                                             <div class="table-cell m-2">
                                                 <th:block th:each="targetUserGameTag, targetUserGameTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()}">
-                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index < 5}" th:text="${targetUserGameTag.getName()}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
-<!--                                                        <span th:text="${targetUserGameTag.getName()}"></span>-->
+                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index < 5}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+                                                        <span th:text="${targetUserGameTag.getName()}"></span>
                                                     </div>
                                                     <div th:if="${targetUserGameTagId.index} >= 5 and ${targetUserGameTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()) - 1}"
                                                          class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
@@ -321,8 +321,8 @@
                                             </div>
                                             <div class="table-cell m-2">
                                                 <th:block th:each="targetUserGenreTag, targetUserGenreTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()}">
-                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" th:text="${targetUserGenreTag.getGenre()}" class="badge" style="background-color: #878787; color: #FFFFFF;">
-<!--                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>-->
+                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" class="badge" style="background-color: #878787; color: #FFFFFF;">
+                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>
                                                     </div>
                                                     <div th:if="${targetUserGenreTagId.size} >= 5 and ${targetUserGenreTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()) - 1}"
                                                          class="badge" style="background-color: #878787; color: #FFFFFF;">

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -301,18 +301,30 @@
                                         </a>
                                         <div class="flex pt-1" style="display: flex; flex-direction: column">
                                             <div class="table-cell m-2">
+                                                <th:block th:each="targetUserGameTag, targetUserGameTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()}">
                                                 <div class="flex flex-wrap">
-                                                    <div th:if="${!recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag().isEmpty()}" th:each="targetUserGameTag : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index < 5}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
                                                         <span th:text="${targetUserGameTag.getName()}"></span>
                                                     </div>
-                                                </div>
-                                            </div>
-                                            <div class="table-cell m-2">
-                                                <div class="flex flex-wrap">
-                                                    <div th:if="${!recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag().isEmpty()}" th:each="targetUserGenreTag : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()}"  class="badge" style="background-color: #878787; color: #FFFFFF;">
-                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>
+                                                    <div th:if="${targetUserGameTagId.index} >= 5 and ${targetUserGameTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()) - 1}"
+                                                         class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+                                                        <span>...</span>
                                                     </div>
                                                 </div>
+                                                </th:block>
+                                            </div>
+                                            <div class="table-cell m-2">
+                                                <th:block th:each="targetUserGenreTag, targetUserGenreTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()}">
+                                                <div class="flex flex-wrap">
+                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" class="badge" style="background-color: #878787; color: #FFFFFF;">
+                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>
+                                                    </div>
+                                                    <div th:if="${targetUserGenreTagId.size} >= 5 and ${targetUserGenreTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()) - 1}"
+                                                         class="badge" style="background-color: #878787; color: #FFFFFF;">
+                                                        <span>...</span>
+                                                    </div>
+                                                </div>
+                                                </th:block>
                                             </div>
                                         </div>
                                         <div class="card-actions justify-between p-4">

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -239,18 +239,26 @@
                                         </a>
                                         <div class="flex pt-1" style="display: flex; flex-direction: column">
                                             <div class="table-cell m-2">
-                                                <div class="flex flex-wrap">
-                                                    <div th:if="${!friend.getFriend().getUserTag().getGameTag().isEmpty()}" th:each="targetUserGameTag : ${friend.getFriend().getUserTag().getGameTag()}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+                                                <th:block th:each="targetUserGameTag, targetUserGameTagId : ${friend.getFriend().getUserTag().getGameTag()}">
+                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index} < 5" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
                                                         <span th:text="${targetUserGameTag.getName()}"></span>
                                                     </div>
-                                                </div>
+                                                    <div th:if="${targetUserGameTagId.index} >= 5 and ${targetUserGameTagId.index == #lists.size(friend.getFriend().getUserTag().getGameTag()) - 1}"
+                                                         class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+                                                        <span>...</span>
+                                                    </div>
+                                                </th:block>
                                             </div>
                                             <div class="table-cell m-2">
-                                                <div class="flex flex-wrap">
-                                                    <div th:if="${!friend.getFriend().getUserTag().getGenreTag().isEmpty()}" th:each="targetUserGenreTag : ${friend.getFriend().getUserTag().getGenreTag()}"  class="badge" style="background-color: #878787; color: #FFFFFF;" >
+                                                <th:block th:each="targetUserGenreTag, targetUserGenreTagId : ${friend.getFriend().getUserTag().getGenreTag()}">
+                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" class="badge" style="background-color: #878787; color: #FFFFFF;" >
                                                         <span th:text="${targetUserGenreTag.getGenre()}"></span>
                                                     </div>
-                                                </div>
+                                                    <div th:if="${targetUserGenreTagId.index} >= 5 and ${targetUserGenreTagId.index == #lists.size(friend.getFriend().getUserTag().getGenreTag()) - 1}"
+                                                         class="badge" style="background-color: #878787; color: #FFFFFF;">
+                                                        <span>...</span>
+                                                    </div>
+                                                </th:block>
                                             </div>
                                         </div>
                                         <div class="card-actions justify-end items-end p-4">

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -299,31 +299,27 @@
                                                 </progress>
                                             </div>
                                         </a>
-                                        <div class="flex pt-1" style="display: flex; flex-direction: column">
+                                        <div class="flex flex-wrap pt-1" style="display: flex; flex-direction: column">
                                             <div class="table-cell m-2">
                                                 <th:block th:each="targetUserGameTag, targetUserGameTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()}">
-                                                <div class="flex flex-wrap">
-                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index < 5}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
-                                                        <span th:text="${targetUserGameTag.getName()}"></span>
+                                                    <div th:if="${targetUserGameTagId.size} != 0 and ${targetUserGameTagId.index < 5}" th:text="${targetUserGameTag.getName()}" class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
+<!--                                                        <span th:text="${targetUserGameTag.getName()}"></span>-->
                                                     </div>
                                                     <div th:if="${targetUserGameTagId.index} >= 5 and ${targetUserGameTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGameTag()) - 1}"
                                                          class="badge" style="background-color: #00A3FF; color: #FFFFFF;">
                                                         <span>...</span>
                                                     </div>
-                                                </div>
                                                 </th:block>
                                             </div>
                                             <div class="table-cell m-2">
                                                 <th:block th:each="targetUserGenreTag, targetUserGenreTagId : ${recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()}">
-                                                <div class="flex flex-wrap">
-                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" class="badge" style="background-color: #878787; color: #FFFFFF;">
-                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>
+                                                    <div th:if="${targetUserGenreTagId.size} != 0 and ${targetUserGenreTagId.index} < 5" th:text="${targetUserGenreTag.getGenre()}" class="badge" style="background-color: #878787; color: #FFFFFF;">
+<!--                                                        <span th:text="${targetUserGenreTag.getGenre()}"></span>-->
                                                     </div>
                                                     <div th:if="${targetUserGenreTagId.size} >= 5 and ${targetUserGenreTagId.index == #lists.size(recentlyUser.getMatchingPartner().getUser().getUserTag().getGenreTag()) - 1}"
                                                          class="badge" style="background-color: #878787; color: #FFFFFF;">
                                                         <span>...</span>
                                                     </div>
-                                                </div>
                                                 </th:block>
                                             </div>
                                         </div>


### PR DESCRIPTION
**미니 프로필의 게임 및 장르 태그 5개 이하만 보이도록 수정**
- 만약 6개 이상일 시 '...' 태그를 추가해 선택한 태그가 여러 개임을 표시
- 매칭 상세 페이지와 프로필 내의 미니 프로필 디자인 통일성 필요 (ex. margin, padding ...) => 추후 논의
- ---
- [x] 매칭 상세 페이지 내 참여자 목록
- [x] 프로필 내 친구 목록
- [x] 프로필 내 최근 매칭된 유저 목록